### PR TITLE
[MMPI-2] (JM) setup weather

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ Temporary Items
 /config/*
 !/config/config.js.sample
 !/config/jim.config.js
+.npmrc
 
 # Vim
 ## swap

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,5 @@
+# Configuration example file, this one is tracked
+# but ".npmrc" is not tracked, gitignored
+
+# API keys
+openweather-api-key="MYSUPERSECRETKEY"

--- a/config/jim.config.js
+++ b/config/jim.config.js
@@ -7,6 +7,12 @@
  * see https://docs.magicmirror.builders/getting-started/configuration.html#general
  * and https://docs.magicmirror.builders/modules/configuration.html
  */
+
+const FIVE_MINUTES_IN_MS = 300000;
+const LOCATION_ID_NYC = 5128581;
+
+const SECRET_WEATHER_API_KEY = process.env.WEATHER_API_KEY;
+
 let config = {
 	address: "localhost", 	// Address to listen on, can be:
 							// - "localhost", "127.0.0.1", "::1" to listen on loopback interface
@@ -73,8 +79,11 @@ let config = {
 				weatherProvider: "openweathermap",
 				type: "current",
 				location: "New York",
-				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
-				apiKey: "YOUR_OPENWEATHER_API_KEY"
+				locationID: LOCATION_ID_NYC,
+				apiKey: "",
+				degreeLabel: true,
+				updateInterval: FIVE_MINUTES_IN_MS,
+				showHumidity: true,
 			}
 		},
 		{
@@ -85,8 +94,13 @@ let config = {
 				weatherProvider: "openweathermap",
 				type: "forecast",
 				location: "New York",
-				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
-				apiKey: "YOUR_OPENWEATHER_API_KEY"
+				locationID: LOCATION_ID_NYC,
+				apiKey: "",
+				degreeLabel: true,
+				updateInterval: FIVE_MINUTES_IN_MS,
+				initialLoadDelay: 100,
+				colored: true,
+				showPrecipitationAmount: true,
 			}
 		},
 		{

--- a/config/jim.config.js
+++ b/config/jim.config.js
@@ -10,8 +10,8 @@
 
 const FIVE_MINUTES_IN_MS = 300000;
 const LOCATION_ID_NYC = 5128581;
-
-const SECRET_WEATHER_API_KEY = process.env.WEATHER_API_KEY;
+// replace me, process.env breaks the app https://github.com/MichMich/MagicMirror/issues/1756
+const SECRET_WEATHER_API_KEY = process.env.WEATHER_API_KEY; 
 
 let config = {
 	address: "localhost", 	// Address to listen on, can be:
@@ -80,7 +80,7 @@ let config = {
 				type: "current",
 				location: "New York",
 				locationID: LOCATION_ID_NYC,
-				apiKey: "",
+				apiKey: SECRET_WEATHER_API_KEY,
 				degreeLabel: true,
 				updateInterval: FIVE_MINUTES_IN_MS,
 				showHumidity: true,
@@ -95,7 +95,7 @@ let config = {
 				type: "forecast",
 				location: "New York",
 				locationID: LOCATION_ID_NYC,
-				apiKey: "",
+				apiKey: SECRET_WEATHER_API_KEY,
 				degreeLabel: true,
 				updateInterval: FIVE_MINUTES_IN_MS,
 				initialLoadDelay: 100,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,6 +2134,15 @@
 				}
 			}
 		},
+		"cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "js/electron.js",
 	"scripts": {
 		"start": "DISPLAY=\"${DISPLAY:=:0}\" ./node_modules/.bin/electron js/electron.js",
-		"start:desktop": "node_modules/.bin/electron js/electron.js",
+		"start:desktop": "cross-env WEATHER_API_KEY=$npm_config_openweather_api_key node_modules/.bin/electron js/electron.js",
 		"start:dev": "DISPLAY=\"${DISPLAY:=:0}\" ./node_modules/.bin/electron js/electron.js dev",
 		"server": "node ./serveronly",
 		"install": "echo \"Installing vendor files ...\n\" && cd vendor && npm install --loglevel=error",
@@ -47,6 +47,7 @@
 	},
 	"homepage": "https://magicmirror.builders",
 	"devDependencies": {
+		"cross-env": "^7.0.3",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-jest": "^24.4.2",
 		"eslint-plugin-jsdoc": "^36.1.0",


### PR DESCRIPTION
This is just a PR into my own develop branch on my own forked repository.

Description:
Secret Management Strategy
- Adds pipework for passing in secrets via .npmrc, package.json
- However, trying to access `process.env` breaks inside of electron app
- Pipework will stay, but moving forward, will hard code secrets inside of non tracked config file `config/config.js`

Weather config
- Additional config settings for weather forecast + current weather (both under weather module) added